### PR TITLE
add Yufei Gao's personal website

### DIFF
--- a/_data/people.yml
+++ b/_data/people.yml
@@ -258,7 +258,7 @@ people:
     institution_address: "185 E Stevens Way NE, Seattle, WA 98195"
     email: "ygao2306@gmail.com"
     office: "Paul Allen Center"
-    website: ""
+    website: "https://maryyufei21.github.io/"
     image: "assets/img/people/yufei.jpeg"
     url: "yufei-gao"
 


### PR DESCRIPTION
## Summary
- Adds https://maryyufei21.github.io/ as Yufei Gao's website link in `_data/people.yml`.

## Test plan
- [ ] `bundle exec jekyll serve` and verify the link renders on the people page / Yufei's profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)