### PR TITLE
Add news item for MLSys 2026 kernel contest

### DIFF
--- a/_data/news.yml
+++ b/_data/news.yml
@@ -1,4 +1,9 @@
 news:
+  - id: "2026-05-28-mlsys-kernel-contest"
+    date: "May 28, 2026"
+    title: "Team UW SyFI wins three awards at the FlashInfer AI Kernel Generation Contest at MLSys 2026!"
+    link: "/blog/2026-05-28-mlsys-kernel-contest"
+
   - id: "2026-05-12-vibeserve"
     date: "May 12, 2026"
     title: "Introducing VibeServe: let AI agents write your LLM serving stack end-to-end"


### PR DESCRIPTION
## Summary
- Adds a `_data/news.yml` entry (top of the list, May 28, 2026) for the MLSys 2026 kernel contest blog post, linking to `/blog/2026-05-28-mlsys-kernel-contest`.
- The post itself was already merged in #37; this is the companion news entry that wasn't included there.

## Test plan
- [x] Item renders on `/news/` and the homepage, linking to the post (verified locally)