### PR TITLE
Add M* multimodal serving system to publications

### DIFF
--- a/_data/publications.yml
+++ b/_data/publications.yml
@@ -1,4 +1,13 @@
 index:
+  - id: "mstar"
+    title: "M*: A Modular, Extensible, Serving System for Multimodal Models"
+    authors: ["Atindra Jha", "Naomi Sagan", "Keisuke Kamahori", "Irmak Sivgin", "Rohan Sanda", "Steven Gao", "Mark Horowitz", "Luke Zettlemoyer", "Olivia Hsu", "Jure Leskovec", "Baris Kasikci", "Stephanie Wang"]
+    year: 2026
+    topics: ["LLM Serving"]
+    link: "https://mstar-project.github.io/"
+    pdf: "https://arxiv.org/abs/2606.12688"
+    code: "https://github.com/mstar-project/mstar"
+
   - id: "vibeserve"
     title: "VibeServe: Can AI Agents Build Bespoke LLM Serving Systems?"
     authors: ["Keisuke Kamahori", "Shihang Li", "Simon Peter", "Baris Kasikci"]


### PR DESCRIPTION
Adds [M*: A Modular, Extensible, Serving System for Multimodal Models](https://mstar-project.github.io/) to the publications list.

- Author list follows the arXiv version (12 authors).
- The entry title links directly to the project website (https://mstar-project.github.io/); no separate publication detail page.
- PDF button → arXiv ([2606.12688](https://arxiv.org/abs/2606.12688)); Code button → [mstar-project/mstar](https://github.com/mstar-project/mstar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)