### PR TITLE
Show post author and date in blog post layout

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -4,7 +4,9 @@ layout: default
 
 <div class="row g-5 mb-5">
   <div class="col-md-12 post-content">
-    <h1 class="fw-bold border-bottom pb-3 mb-5">{{ page.title }}</h1>
+    <h1 class="fw-bold mb-2">{{ page.title }}</h1>
+    {% if page.author %}<p class="text-muted mb-1">{{ page.author }}</p>{% endif %}
+    <p class="text-muted border-bottom pb-3 mb-5">{{ page.date | date: "%B %-d, %Y" }}</p>
     {{ content }}
   </div>
 </div>


### PR DESCRIPTION
Blog posts already carry an `author` (and `date`) in their frontmatter, but the post layout only rendered the title. This surfaces them as a byline under the title.

## Changes
- `_layouts/post.html` — render the post's author and date below the title, with the divider beneath both. The author line is guarded with `{% if page.author %}` so posts without one degrade gracefully.

All existing posts have an `author` field, so they all gain the byline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)