### PR TITLE
Generate homepage Venn diagram from publication data

### DIFF
--- a/_includes/research_areas_diagram.html
+++ b/_includes/research_areas_diagram.html
@@ -1,0 +1,129 @@
+{%- capture efficient_only -%}
+  {%- for pub in site.data.publications.index -%}
+    {%- assign area_count = pub.areas | size -%}
+    {%- if pub.show_in_venn and area_count == 1 and pub.areas contains "efficient_ai" -%}
+      {%- include research_areas_diagram_item.html pub=pub -%}
+    {%- endif -%}
+  {%- endfor -%}
+{%- endcapture -%}
+{%- assign efficient_only = efficient_only | strip -%}
+
+{%- capture flexible_only -%}
+  {%- for pub in site.data.publications.index -%}
+    {%- assign area_count = pub.areas | size -%}
+    {%- if pub.show_in_venn and area_count == 1 and pub.areas contains "flexible_ai" -%}
+      {%- include research_areas_diagram_item.html pub=pub -%}
+    {%- endif -%}
+  {%- endfor -%}
+{%- endcapture -%}
+{%- assign flexible_only = flexible_only | strip -%}
+
+{%- capture resilient_only -%}
+  {%- for pub in site.data.publications.index -%}
+    {%- assign area_count = pub.areas | size -%}
+    {%- if pub.show_in_venn and area_count == 1 and pub.areas contains "resilient_ai" -%}
+      {%- include research_areas_diagram_item.html pub=pub -%}
+    {%- endif -%}
+  {%- endfor -%}
+{%- endcapture -%}
+{%- assign resilient_only = resilient_only | strip -%}
+
+{%- capture efficient_flexible -%}
+  {%- for pub in site.data.publications.index -%}
+    {%- assign area_count = pub.areas | size -%}
+    {%- if pub.show_in_venn and area_count == 2 and pub.areas contains "efficient_ai" and pub.areas contains "flexible_ai" -%}
+      {%- include research_areas_diagram_item.html pub=pub -%}
+    {%- endif -%}
+  {%- endfor -%}
+{%- endcapture -%}
+{%- assign efficient_flexible = efficient_flexible | strip -%}
+
+{%- capture efficient_resilient -%}
+  {%- for pub in site.data.publications.index -%}
+    {%- assign area_count = pub.areas | size -%}
+    {%- if pub.show_in_venn and area_count == 2 and pub.areas contains "efficient_ai" and pub.areas contains "resilient_ai" -%}
+      {%- include research_areas_diagram_item.html pub=pub -%}
+    {%- endif -%}
+  {%- endfor -%}
+{%- endcapture -%}
+{%- assign efficient_resilient = efficient_resilient | strip -%}
+
+{%- capture flexible_resilient -%}
+  {%- for pub in site.data.publications.index -%}
+    {%- assign area_count = pub.areas | size -%}
+    {%- if pub.show_in_venn and area_count == 2 and pub.areas contains "flexible_ai" and pub.areas contains "resilient_ai" -%}
+      {%- include research_areas_diagram_item.html pub=pub -%}
+    {%- endif -%}
+  {%- endfor -%}
+{%- endcapture -%}
+{%- assign flexible_resilient = flexible_resilient | strip -%}
+
+{%- capture all_areas -%}
+  {%- for pub in site.data.publications.index -%}
+    {%- assign area_count = pub.areas | size -%}
+    {%- if pub.show_in_venn and area_count == 3 and pub.areas contains "efficient_ai" and pub.areas contains "flexible_ai" and pub.areas contains "resilient_ai" -%}
+      {%- include research_areas_diagram_item.html pub=pub -%}
+    {%- endif -%}
+  {%- endfor -%}
+{%- endcapture -%}
+{%- assign all_areas = all_areas | strip -%}
+
+<figure class="research-areas-diagram">
+  <figcaption class="visually-hidden">
+    Featured SyFI publications grouped by Efficient AI, Flexible AI, and Resilient AI.
+  </figcaption>
+  <div class="research-areas-venn" aria-hidden="false">
+    <svg class="research-areas-venn-circles" viewBox="0 0 600 540" role="img" aria-labelledby="research-areas-title research-areas-desc" focusable="false">
+      <title id="research-areas-title">SyFI research areas</title>
+      <desc id="research-areas-desc">A three-circle Venn diagram for Efficient AI, Flexible AI, and Resilient AI.</desc>
+      <circle class="research-areas-circle research-areas-circle--resilient" cx="403" cy="340" r="191" />
+      <circle class="research-areas-circle research-areas-circle--flexible" cx="275" cy="191" r="191" />
+      <circle class="research-areas-circle research-areas-circle--efficient" cx="191" cy="300" r="191" />
+      <text class="research-areas-label" x="275" y="45" text-anchor="middle">Flexible AI</text>
+      <text class="research-areas-label" x="170" y="445" text-anchor="middle">Efficient AI</text>
+      <text class="research-areas-label" x="467" y="445" text-anchor="middle">Resilient AI</text>
+    </svg>
+
+    {%- if flexible_only != "" -%}
+      <div class="research-areas-region research-areas-region--flexible" aria-label="Flexible AI papers">
+        <ul>{{ flexible_only }}</ul>
+      </div>
+    {%- endif -%}
+
+    {%- if efficient_only != "" -%}
+      <div class="research-areas-region research-areas-region--efficient" aria-label="Efficient AI papers">
+        <ul>{{ efficient_only }}</ul>
+      </div>
+    {%- endif -%}
+
+    {%- if resilient_only != "" -%}
+      <div class="research-areas-region research-areas-region--resilient" aria-label="Resilient AI papers">
+        <ul>{{ resilient_only }}</ul>
+      </div>
+    {%- endif -%}
+
+    {%- if efficient_flexible != "" -%}
+      <div class="research-areas-region research-areas-region--efficient-flexible" aria-label="Efficient AI and Flexible AI papers">
+        <ul>{{ efficient_flexible }}</ul>
+      </div>
+    {%- endif -%}
+
+    {%- if efficient_resilient != "" -%}
+      <div class="research-areas-region research-areas-region--efficient-resilient" aria-label="Efficient AI and Resilient AI papers">
+        <ul>{{ efficient_resilient }}</ul>
+      </div>
+    {%- endif -%}
+
+    {%- if flexible_resilient != "" -%}
+      <div class="research-areas-region research-areas-region--flexible-resilient" aria-label="Flexible AI and Resilient AI papers">
+        <ul>{{ flexible_resilient }}</ul>
+      </div>
+    {%- endif -%}
+
+    {%- if all_areas != "" -%}
+      <div class="research-areas-region research-areas-region--all" aria-label="Efficient AI, Flexible AI, and Resilient AI papers">
+        <ul>{{ all_areas }}</ul>
+      </div>
+    {%- endif -%}
+  </div>
+</figure>

--- a/_includes/research_areas_diagram_item.html
+++ b/_includes/research_areas_diagram_item.html
@@ -1,0 +1,13 @@
+{%- assign pub = include.pub -%}
+{%- if pub.link -%}
+  {%- assign pub_url = pub.link -%}
+{%- elsif pub.pdf -%}
+  {%- assign pub_url = pub.pdf -%}
+{%- else -%}
+  {%- capture pub_url -%}{{ site.github.url }}/publications/{{ pub.id }}/{%- endcapture -%}
+{%- endif -%}
+<li>
+  <a class="research-areas-paper" href="{{ pub_url }}" aria-label="{{ pub.title | escape }}">
+    {{ pub.short_title | default: pub.title }}
+  </a>
+</li>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -4,13 +4,8 @@ layout: default
 
 <!-- Section 1: Lab Introduction & Research Areas -->
 <div class="mb-5">
-  <div class="float-md-end ms-md-4 mb-3" style="max-width: 360px;">
-    <object
-      data="{{ site.github.url }}/assets/svg/areas.svg"
-      type="image/svg+xml"
-      width="100%"
-      style="display: block;"
-    ></object>
+  <div class="float-md-end ms-md-4 mb-3 research-areas-home">
+    {% include research_areas_diagram.html %}
   </div>
   <div class="clearfix">
     {{ content }}

--- a/_sass/style.scss
+++ b/_sass/style.scss
@@ -69,6 +69,123 @@ h4, h5, h6 {
   color: #5600b3;
 }
 
+// Homepage research areas diagram
+.research-areas-home {
+  max-width: 360px;
+  width: 100%;
+}
+
+.research-areas-diagram {
+  margin: 0;
+}
+
+.research-areas-venn {
+  aspect-ratio: 10 / 9;
+  position: relative;
+  width: 100%;
+}
+
+.research-areas-venn-circles {
+  display: block;
+  height: 100%;
+  width: 100%;
+}
+
+.research-areas-circle {
+  fill-opacity: 0.5;
+  stroke: none;
+}
+
+.research-areas-circle--efficient {
+  fill: #fff2cc;
+}
+
+.research-areas-circle--flexible {
+  fill: #f4cccc;
+}
+
+.research-areas-circle--resilient {
+  fill: #cfe2f3;
+}
+
+.research-areas-label {
+  fill: #595959;
+  font-size: 26px;
+  font-weight: 600;
+}
+
+.research-areas-region {
+  position: absolute;
+  z-index: 1;
+}
+
+.research-areas-region ul {
+  display: grid;
+  gap: 0.18rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.research-areas-paper {
+  background: #ffffff;
+  border: 1px solid #707070;
+  color: #000000;
+  display: block;
+  font-size: 0.68rem;
+  line-height: 1.1;
+  min-height: 1.25rem;
+  overflow-wrap: anywhere;
+  padding: 0.16rem 0.28rem;
+  text-align: center;
+}
+
+.research-areas-paper:hover {
+  color: #5600b3;
+}
+
+.research-areas-region--flexible {
+  left: 38%;
+  top: 14%;
+  width: 25%;
+}
+
+.research-areas-region--efficient {
+  left: 3%;
+  top: 49%;
+  width: 25%;
+}
+
+.research-areas-region--resilient {
+  left: 73%;
+  top: 55%;
+  width: 24%;
+}
+
+.research-areas-region--efficient-flexible {
+  left: 26%;
+  top: 25%;
+  width: 27%;
+}
+
+.research-areas-region--efficient-resilient {
+  left: 43%;
+  top: 69%;
+  width: 29%;
+}
+
+.research-areas-region--flexible-resilient {
+  left: 55%;
+  top: 36%;
+  width: 28%;
+}
+
+.research-areas-region--all {
+  left: 40%;
+  top: 43%;
+  width: 23%;
+}
+
 // Blog post body links
 .post-content a {
   color: #0a58ca;
@@ -120,6 +237,12 @@ img {
 @media (max-width: 767.98px) {
   .site-brand {
     justify-content: center;
+  }
+
+  .research-areas-home {
+    float: none !important;
+    margin-left: auto !important;
+    margin-right: auto !important;
   }
 
   .site-logo {


### PR DESCRIPTION
## Summary
- replace the static homepage SVG object with a build-time Liquid include
- render Venn circles, area labels, and publication links from `_data/publications.yml`
- add scoped homepage styles for the generated diagram

## Stack
1. #52: metadata layer
2. This PR: generated homepage include
3. #54: latest featured papers

Resolves #50.
Part of #48.

## Validation
- `bundle exec jekyll build`
- checked generated `_site/index.html` for data-driven Venn links
- final stack visual check: desktop/mobile screenshots with 16 links and 0 measured overlaps