### PR TITLE
Feature latest papers in homepage Venn diagram

### DIFF
--- a/_data/publications.yml
+++ b/_data/publications.yml
@@ -114,9 +114,12 @@ index:
 
   - id: "raydata"
     title: "The Streaming Batch Model for Efficient and Fault-Tolerant Heterogeneous Execution"
+    short_title: "Ray Data"
     authors: ["Frank Sifei Luan", "Ron Yifeng Wang", "Yile Gu", "Ziming Mao", "Charlotte Lin", "Amog Kamsetty", "Hao Chen", "Cheng Su", "Balaji Veeramani", "Scott Lee", "SangBin Cho", "Clark Zinzow", "Eric Liang", "Ion Stoica", "Stephanie Wang"]
     year: 2025
     topics: ["ML+Data", "Efficient AI", "Flexible AI"]
+    areas: ["efficient_ai", "flexible_ai"]
+    show_in_venn: true
     pdf: "https://arxiv.org/abs/2501.12407"
 
   - id: "distscheduling"
@@ -165,10 +168,13 @@ index:
 
   - id: "argos"
     title: "Argos: Detecting Dynamic Anomalies in the Cloud with Rule Generation"
+    short_title: "Argos"
     authors: ["Yile Gu", "Hoang Doan Nguyen", "Demirhan Celik", "Sifat Hasan", "Yifan Xiong", "Jonathan Mace", "Yuting Jiang", "Yigong Hu", "Baris Kasikci", "Peng Cheng"]
     venue: "arXiv preprint (2025)"
     year: 2025
     topics: ["Agents", "Cloud Reliability"]
+    areas: ["resilient_ai"]
+    show_in_venn: true
     pdf: "https://arxiv.org/pdf/2501.14170"
 
   - id: "nanoflow"
@@ -194,6 +200,17 @@ index:
     areas: ["efficient_ai", "resilient_ai"]
     show_in_venn: true
     link: "https://syfi.cs.washington.edu/publications/magneton/"
+
+  - id: "gigiprofiler"
+    title: "gigiProfiler: Diagnosing Performance Issues by Uncovering Application Resource Bottlenecks"
+    short_title: "gigiProfiler"
+    authors: ["Yigong Hu", "Haodong Zheng", "Yicheng Liu", "Dedong Xie", "Youliang Huang", "Baris Kasikci"]
+    venue: "arXiv preprint (2025)"
+    year: 2025
+    topics: ["Performance Debugging", "Resource Bottlenecks"]
+    areas: ["efficient_ai", "resilient_ai"]
+    show_in_venn: true
+    pdf: "https://arxiv.org/abs/2507.06452"
 
   - id: "mlsystemsextensibility"
     title: "Towards ML System Extensibility"

--- a/_data/publications.yml
+++ b/_data/publications.yml
@@ -1,53 +1,71 @@
 index:
   - id: "mstar"
     title: "M*: A Modular, Extensible, Serving System for Multimodal Models"
+    short_title: "M*"
     authors: ["Atindra Jha", "Naomi Sagan", "Keisuke Kamahori", "Irmak Sivgin", "Rohan Sanda", "Steven Gao", "Mark Horowitz", "Luke Zettlemoyer", "Olivia Hsu", "Jure Leskovec", "Baris Kasikci", "Stephanie Wang"]
     year: 2026
     topics: ["LLM Serving"]
+    areas: ["efficient_ai", "flexible_ai"]
+    show_in_venn: true
     link: "https://m-star.org/"
     pdf: "https://arxiv.org/abs/2606.12688"
     code: "https://github.com/mstar-project/mstar"
 
   - id: "vibeserve"
     title: "VibeServe: Can AI Agents Build Bespoke LLM Serving Systems?"
+    short_title: "VibeServe"
     authors: ["Keisuke Kamahori", "Shihang Li", "Simon Peter", "Baris Kasikci"]
     year: 2026
     topics: ["LLM Serving"]
+    areas: ["efficient_ai", "flexible_ai"]
+    show_in_venn: true
     link: "https://syfi.cs.washington.edu/blog/2026-05-12-introducing-vibeserve/"
     pdf: "https://arxiv.org/abs/2605.06068"
     code: "https://github.com/uw-syfi/vibe-serve"
 
   - id: "voxserve"
     title: "VoxServe: Streaming-Centric Serving System for Speech Language Models"
+    short_title: "VoxServe"
     authors: ["Keisuke Kamahori", "Wei-Tzu Lee", "Atindra Jha", "Rohan Kadekodi", "Stephanie Wang", "Arvind Krishnamurthy", "Baris Kasikci"]
     year: 2026
     topics: ["LLM Serving"]
+    areas: ["efficient_ai", "flexible_ai"]
+    show_in_venn: true
     link: "https://syfi.cs.washington.edu/blog/2025-09-29-introducing-vox-serve/"
     pdf: "https://arxiv.org/abs/2602.00269"
     code: "https://github.com/vox-serve/vox-serve"
 
   - id: "ibp"
     title: "Reducing the GPU Memory Bottleneck with Lossless Compression for ML"
+    short_title: "IBP"
     authors: ["Aditya K Kamath", "Arvind Krishnamurthy", "Marco Canini", "Simon Peter"]
     venue: "European Conference on Computer Systems (EuroSys)"
     year: 2026
     topics: ["Efficient AI"]
+    areas: ["efficient_ai"]
+    show_in_venn: true
     pdf: "/assets/papers/ibp.pdf"
 
   - id: "flashinfer-bench"
     title: "FlashInfer-Bench: Building the Virtuous Cycle for AI-driven LLM Systems"
+    short_title: "FI-Bench"
     authors: ["Shanli Xing", "Yiyan Zhai", "Alexander Jiang", "Yixin Dong", "Yong Wu", "Zihao Ye", "Charlie Ruan", "Yingyi Huang", "Yineng Zhang", "Liangsheng Yin", "Aksara Bayyapu", "Luis Ceze", "Tianqi Chen"]
     venue: "Annual Conference on Machine Learning and Systems (MLSys)"
     year: 2026
     topics: ["LLM Serving"]
+    areas: ["efficient_ai", "flexible_ai"]
+    show_in_venn: true
     pdf: "https://arxiv.org/abs/2601.00227"
 
   - id: "sparsespec"
     title: "Accelerating Large-Scale Reasoning Model Inference with Sparse Self-Speculative Decoding"
+    short_title: "SparseSpec"
     authors: ["Yilong Zhao", "Jiaming Tang", "Kan Zhu", "Zihao Ye", "Chi-Chih Chang", "Chaofan Lin", "Jongseok Park", "Guangxuan Xiao", "Mohamed S. Abdelfattah", "Mingyu Gao", "Baris Kasikci", "Song Han", "Ion Stoica"]
     venue: "Annual Conference on Machine Learning and Systems (MLSys)"
     year: 2026
     topics: ["LLM Serving"]
+    areas: ["efficient_ai"]
+    show_in_venn: true
     pdf: "https://arxiv.org/abs/2512.01278"
 
   - id: "dynaflow"
@@ -62,10 +80,13 @@ index:
 
   - id: "fcp"
     title: "Unleashing Scalable Context Parallelism for Foundation Models Pre-Training via FCP"
+    short_title: "FCP"
     authors: ["Yilong Zhao", "Xiaonan Nie", "Kan Zhu", "Shuang Ma", "Zhichao Lai", "Hongxiang Hao", "Yang Zhou", "Baris Kasikci", "Ion Stoica"]
     venue: "Annual Conference on Machine Learning and Systems (MLSys)"
     year: 2026
     topics: ["Distributed Training"]
+    areas: ["efficient_ai", "flexible_ai"]
+    show_in_venn: true
 
   - id: "telerag"
     title: "TeleRAG: Efficient Retrieval-Augmented Generation Inference with Lookahead Retrieval"
@@ -82,10 +103,13 @@ index:
 
   - id: "tactic"
     title: "Tactic: Adaptive Sparse Attention with Clustering and Distribution Fitting for Long-Context LLMs"
+    short_title: "Tactic"
     authors: ["Kan Zhu", "Tian Tang", "Qinyu Xu", "Yile Gu", "Zhichen Zeng", "Rohan Kadekodi", "Liangyu Zhao", "Ang Li", "Arvind Krishnamurthy", "Baris Kasikci"]
     venue: "International Conference on Learning Representations (ICLR)"
     year: 2026
     topics: ["LLM Serving"]
+    areas: ["efficient_ai"]
+    show_in_venn: true
     pdf: "https://arxiv.org/pdf/2502.12216"
 
   - id: "raydata"

--- a/_includes/research_areas_diagram.html
+++ b/_includes/research_areas_diagram.html
@@ -80,8 +80,8 @@
       <circle class="research-areas-circle research-areas-circle--flexible" cx="275" cy="191" r="191" />
       <circle class="research-areas-circle research-areas-circle--efficient" cx="191" cy="300" r="191" />
       <text class="research-areas-label" x="275" y="45" text-anchor="middle">Flexible AI</text>
-      <text class="research-areas-label" x="162" y="510" text-anchor="middle">Efficient AI</text>
-      <text class="research-areas-label" x="470" y="510" text-anchor="middle">Resilient AI</text>
+      <text class="research-areas-label" x="191" y="470" text-anchor="middle">Efficient AI</text>
+      <text class="research-areas-label" x="403" y="490" text-anchor="middle">Resilient AI</text>
     </svg>
 
     {%- if flexible_only != "" -%}

--- a/_includes/research_areas_diagram.html
+++ b/_includes/research_areas_diagram.html
@@ -76,12 +76,12 @@
     <svg class="research-areas-venn-circles" viewBox="0 0 600 540" role="img" aria-labelledby="research-areas-title research-areas-desc" focusable="false">
       <title id="research-areas-title">SyFI research areas</title>
       <desc id="research-areas-desc">A three-circle Venn diagram for Efficient AI, Flexible AI, and Resilient AI.</desc>
-      <circle class="research-areas-circle research-areas-circle--resilient" cx="403" cy="340" r="191" />
+      <circle class="research-areas-circle research-areas-circle--resilient" cx="403" cy="300" r="191" />
       <circle class="research-areas-circle research-areas-circle--flexible" cx="275" cy="191" r="191" />
       <circle class="research-areas-circle research-areas-circle--efficient" cx="191" cy="300" r="191" />
       <text class="research-areas-label" x="275" y="45" text-anchor="middle">Flexible AI</text>
       <text class="research-areas-label" x="191" y="470" text-anchor="middle">Efficient AI</text>
-      <text class="research-areas-label" x="403" y="490" text-anchor="middle">Resilient AI</text>
+      <text class="research-areas-label" x="403" y="470" text-anchor="middle">Resilient AI</text>
     </svg>
 
     {%- if flexible_only != "" -%}

--- a/_includes/research_areas_diagram.html
+++ b/_includes/research_areas_diagram.html
@@ -80,8 +80,8 @@
       <circle class="research-areas-circle research-areas-circle--flexible" cx="275" cy="191" r="191" />
       <circle class="research-areas-circle research-areas-circle--efficient" cx="191" cy="300" r="191" />
       <text class="research-areas-label" x="275" y="45" text-anchor="middle">Flexible AI</text>
-      <text class="research-areas-label" x="170" y="445" text-anchor="middle">Efficient AI</text>
-      <text class="research-areas-label" x="467" y="445" text-anchor="middle">Resilient AI</text>
+      <text class="research-areas-label" x="162" y="510" text-anchor="middle">Efficient AI</text>
+      <text class="research-areas-label" x="470" y="510" text-anchor="middle">Resilient AI</text>
     </svg>
 
     {%- if flexible_only != "" -%}

--- a/_sass/style.scss
+++ b/_sass/style.scss
@@ -151,9 +151,9 @@ h4, h5, h6 {
 }
 
 .research-areas-region--efficient {
-  left: 3%;
-  top: 49%;
-  width: 25%;
+  left: 0;
+  top: 50%;
+  width: 23%;
 }
 
 .research-areas-region--resilient {
@@ -163,15 +163,15 @@ h4, h5, h6 {
 }
 
 .research-areas-region--efficient-flexible {
-  left: 26%;
-  top: 25%;
-  width: 27%;
+  left: 24%;
+  top: 22%;
+  width: 25%;
 }
 
 .research-areas-region--efficient-resilient {
-  left: 43%;
-  top: 69%;
-  width: 29%;
+  left: 72%;
+  top: 70%;
+  width: 26%;
 }
 
 .research-areas-region--flexible-resilient {
@@ -181,9 +181,9 @@ h4, h5, h6 {
 }
 
 .research-areas-region--all {
-  left: 40%;
-  top: 43%;
-  width: 23%;
+  left: 50%;
+  top: 44%;
+  width: 20%;
 }
 
 // Blog post body links

--- a/_sass/style.scss
+++ b/_sass/style.scss
@@ -115,29 +115,39 @@ h4, h5, h6 {
 }
 
 .research-areas-region {
+  inset: 0;
+  pointer-events: none;
   position: absolute;
   z-index: 1;
 }
 
 .research-areas-region ul {
-  display: grid;
-  gap: 0.18rem;
+  inset: 0;
   list-style: none;
   margin: 0;
   padding: 0;
+  position: absolute;
+}
+
+.research-areas-region li {
+  position: absolute;
+  width: max-content;
 }
 
 .research-areas-paper {
   background: #ffffff;
   border: 1px solid #707070;
   color: #000000;
-  display: block;
-  font-size: 0.68rem;
+  display: inline-block;
+  font-size: 0.6rem;
   line-height: 1.1;
-  min-height: 1.25rem;
+  min-height: 1.1rem;
+  min-width: 1.75rem;
   overflow-wrap: anywhere;
-  padding: 0.16rem 0.28rem;
+  padding: 0.14rem 0.22rem;
+  pointer-events: auto;
   text-align: center;
+  white-space: nowrap;
 }
 
 .research-areas-paper:hover {
@@ -145,45 +155,144 @@ h4, h5, h6 {
 }
 
 .research-areas-region--flexible {
-  left: 38%;
-  top: 14%;
-  width: 25%;
+  left: 0;
+  top: 0;
+  width: 100%;
 }
 
 .research-areas-region--efficient {
   left: 0;
-  top: 50%;
-  width: 23%;
+  top: 0;
+  width: 100%;
 }
 
 .research-areas-region--resilient {
-  left: 73%;
-  top: 55%;
-  width: 24%;
+  left: 0;
+  top: 0;
+  width: 100%;
 }
 
 .research-areas-region--efficient-flexible {
-  left: 24%;
-  top: 22%;
-  width: 25%;
+  left: 0;
+  top: 0;
+  width: 100%;
 }
 
 .research-areas-region--efficient-resilient {
-  left: 72%;
-  top: 70%;
-  width: 26%;
+  left: 0;
+  top: 0;
+  width: 100%;
 }
 
 .research-areas-region--flexible-resilient {
-  left: 55%;
-  top: 36%;
-  width: 28%;
+  left: 0;
+  top: 0;
+  width: 100%;
 }
 
 .research-areas-region--all {
-  left: 50%;
-  top: 44%;
-  width: 20%;
+  left: 0;
+  top: 0;
+  width: 100%;
+}
+
+.research-areas-region--efficient li:nth-child(1) {
+  left: 4%;
+  top: 42%;
+}
+
+.research-areas-region--efficient li:nth-child(2) {
+  left: 20%;
+  top: 48%;
+}
+
+.research-areas-region--efficient li:nth-child(3) {
+  left: 5%;
+  top: 64%;
+}
+
+.research-areas-region--efficient li:nth-child(4) {
+  left: 2%;
+  top: 58%;
+}
+
+.research-areas-region--efficient li:nth-child(5) {
+  left: 8%;
+  top: 70%;
+}
+
+.research-areas-region--efficient li:nth-child(6) {
+  left: 2%;
+  top: 49%;
+}
+
+.research-areas-region--resilient li:nth-child(1) {
+  left: 75%;
+  top: 69%;
+}
+
+.research-areas-region--efficient-flexible li:nth-child(1) {
+  left: 45%;
+  top: 15%;
+}
+
+.research-areas-region--efficient-flexible li:nth-child(2) {
+  left: 23%;
+  top: 20%;
+}
+
+.research-areas-region--efficient-flexible li:nth-child(3) {
+  left: 55%;
+  top: 24%;
+}
+
+.research-areas-region--efficient-flexible li:nth-child(4) {
+  left: 40%;
+  top: 31%;
+}
+
+.research-areas-region--efficient-flexible li:nth-child(5) {
+  left: 22%;
+  top: 38%;
+}
+
+.research-areas-region--efficient-flexible li:nth-child(6) {
+  left: 56%;
+  top: 36%;
+}
+
+.research-areas-region--efficient-flexible li:nth-child(7) {
+  left: 45%;
+  top: 43%;
+}
+
+.research-areas-region--efficient-flexible li:nth-child(8) {
+  left: 39%;
+  top: 50%;
+}
+
+.research-areas-region--efficient-flexible li:nth-child(9) {
+  left: 20%;
+  top: 26%;
+}
+
+.research-areas-region--efficient-flexible li:nth-child(10) {
+  left: 29%;
+  top: 59%;
+}
+
+.research-areas-region--efficient-resilient li {
+  width: max-content;
+}
+
+.research-areas-region--efficient-resilient li:nth-child(1) {
+  left: 45%;
+  top: 69%;
+}
+
+.research-areas-region--efficient-resilient li:nth-child(2) {
+  left: 46%;
+  top: 62%;
 }
 
 // Blog post body links


### PR DESCRIPTION
## Summary
- mark the 2026 publication entries for homepage Venn display
- add concise `short_title` and `areas` metadata for the latest papers, plus `Argos`, `Ray Data`, and `gigiProfiler`
- auto-layout Venn labels from rendered circle geometry and publication `areas`, with a grouped no-JS fallback
- keep all Venn circles equal-sized and Efficient/Resilient aligned while giving two-way cells enough label space

## Stack
1. #52: metadata layer
2. #53: generated homepage include
3. This PR: latest featured papers and auto-layout

Resolves #51.
Resolves #56.
Part of #48.

## Validation
- `bundle exec jekyll build`
- `node --check assets/js/research_areas_layout.js`
- Playwright/Chromium screenshot pass at 900px desktop and 390px mobile
- automated rendered checks: 19 Venn links, 0 paper overlaps, 0 title overlaps, 0 exact-cell misses at both viewport sizes
- rendered circle check: equal radii and aligned Efficient/Resilient centers
