### PR TITLE
[codex] Add May and June 2026 talks

### DIFF
--- a/_talks/2026-05-22-mohamed-abdelfattah.md
+++ b/_talks/2026-05-22-mohamed-abdelfattah.md
@@ -1,0 +1,17 @@
+---
+speaker: Mohamed Abdelfattah
+affiliation: Cornell University
+title: 'Extreme Codesign for Efficient AI: Algorithms, Software, and Hardware'
+date: '2026-05-22'
+homepage: https://www.mohsaied.com/
+---
+
+<img src="https://www.mohsaied.com/assets/img/prof_pic.jpg" alt="Mohamed Abdelfattah" width="240">
+
+## Abstract
+
+Large language model (LLM) inference is computationally expensive and increasingly dominated by memory bandwidth. This talk presents a set of hardware, software, and algorithmic techniques that address these bottlenecks through cross-layer co-design, spanning numerical representation, tensor compression, and custom hardware accelerator architectures. I make the case that we are well past the point of "traditional codesign" to get to higher computing speeds, and we need to move towards Extreme Codesign where the lines between algorithm, software, and hardware abstractions are being blurred in the pursuit of performance for AI systems.
+
+## Speaker Bio
+
+Mohamed Abdelfattah is an Assistant Professor at Cornell Tech and in the Electrical and Computer Engineering Department at Cornell University. His research group is designing the next generation of machine-learning-centric computer systems for both datacenters and mobile devices. He received his BSc from the German University in Cairo, his MSc from the University of Stuttgart, and his PhD from the University of Toronto. After his PhD, Mohamed spent six years at Intel and Samsung Research. Recently, he co-founded a startup, Makora, to automate performance optimizations for AI. He is the recipient of multiple best paper awards, the Vanier Canada Graduate Scholarship, and the NSF CAREER award.

--- a/_talks/2026-05-29-jiayi-chen.md
+++ b/_talks/2026-05-29-jiayi-chen.md
@@ -1,0 +1,18 @@
+---
+speaker: Jiayi (Jane) Chen
+affiliation: The University of Texas at Austin
+title: 'ML for Systems in the Real World: Challenges Beyond Training the Models'
+date: '2026-05-29'
+---
+
+## Abstract
+
+There has been growing interest in applying machine learning to improve system performance, particularly because of its capability of adapting to heterogeneous and dynamic environments. But making ML effective in real systems requires addressing challenges that go well beyond training a model. In this talk, I will present two pieces of my work that tackle fundamental obstacles in this space.
+
+The first challenge is accurate state representation. The performance of learned controllers depends heavily on the fidelity of their input features. Yet, current network controllers rely on hand-made instantaneous or running-average metrics that provide coarse, delayed, or incomplete views of the true network state. I will describe UNUM, which constructs system-wide state embeddings to enable higher-quality and coordinated policy decisions.
+
+The second challenge is efficient and adaptable deployment. For many system problems, constructing a single large learned model is impractical or unnecessarily costly. I will present Darwin, a neural-aided expert selection system that makes ML-driven policies practical by balancing instance-optimal decisions with generalization and runtime overhead.
+
+## Speaker Bio
+
+Jiayi (Jane) Chen is a fifth-year Ph.D. student in Computer Science at The University of Texas at Austin, advised by Professor Aditya Akella and Professor Sanjay Shakkottai. Her research lies at the intersection of machine learning, networks, and systems. Her work focuses on structuring how AI can be used within systems by designing abstractions, frameworks, and reusable components that enable learning-based techniques to be systematically integrated into system design and operation. She is part of the Learning-Directed Operating System (LDOS) expedition. Her work has appeared in SIGCOMM, NSDI, NeurIPS, HotOS.

--- a/_talks/2026-06-12-jianming-tong.md
+++ b/_talks/2026-06-12-jianming-tong.md
@@ -1,0 +1,15 @@
+---
+speaker: Jianming Tong
+affiliation: Georgia Tech
+title: Enabling ASIC AI Chips for Cryptography Primitives
+date: '2026-06-12'
+homepage: https://jianmingtong.github.io/
+---
+
+## Abstract
+
+Cryptography-based applications powered a $3.5T market in 2025, yet demand for cryptographic computation already outpaces today's available compute by roughly 10x. Closing this gap will require not just more hardware, but a new way to unlock far more performance from the hardware we already have. In this talk, we will introduce CROSS [HPCA'26] and MORPH [DAC'26], which develop compiler transformations that map cryptographic workloads--homomorphic encryption (HE) for privacy-preserving AI and zero-knowledge proofs (ZKP) for cryptocurrency--onto AI ASICs (Google TPUs), achieving up-to 10x higher throughput than SoTA GPUs/FPGAs, without hardware changes. More broadly, our insight is that dedicated hardware (ASICs such as Google's TPU) shouldn't be pigeonholed by their original intent ("AI-only"), but by their computational capabilities (high-throughput matrix/vector engines and coarse-grained memory reordering). A compiler can systematically retarget non-AI domains onto these capabilities, expanding what "AI ASICs" can accelerate.
+
+## Speaker Bio
+
+[Jianming Tong](https://jianmingtong.github.io/) is a 5th-year PhD, Student Researcher at Google. He focuses on enabling AI system for applications beyond AI such as cryptography and using AI to improve kernels and architectures. A few representative highlights include CROSS [[HPCA'26](https://ieeexplore.ieee.org/abstract/document/11408507) w/ Google], MORPH [[DAC'26](https://arxiv.org/abs/2604.17808) w/ Google], FEATHER [[ISCA'24](https://ieeexplore.ieee.org/stamp/stamp.jsp?arnumber=10609591)], MINISA [[ISPASS'26](https://arxiv.org/abs/2603.20623)] and PRIVATAR ([MLSys'26](https://arxiv.org/abs/2604.17476)).


### PR DESCRIPTION
## Summary

Adds three new talk pages for the 2026 talks collection:

- Mohamed Abdelfattah, May 22, 2026
- Jiayi (Jane) Chen, May 29, 2026
- Jianming Tong, June 12, 2026

The new entries use the existing `_talks` Markdown format and include Jianming Tong's affiliation as Georgia Tech. Mohamed Abdelfattah's supplied photo is embedded on the talk page at a constrained portrait width.

## Validation

- Ran `bundle exec jekyll build`
- Confirmed the local served site returned HTTP 200 on `http://127.0.0.1:62334/`
- Confirmed the generated talks pages include the new entries

Notes: the build still reports pre-existing warnings for malformed front matter in `publications/argos.md` and a Sass `@import` deprecation in `assets/css/main.scss`; those files are unrelated to this change.
