### PR TITLE
TraceLab: point paper links + BibTeX to arXiv (2606.30560)

### DIFF
--- a/_data/publications.yml
+++ b/_data/publications.yml
@@ -5,7 +5,7 @@ index:
     year: 2026
     topics: ["LLM Serving"]
     link: "https://syfi.cs.washington.edu/blog/2026-06-25-tracelab/"
-    pdf: "https://tracelab.cs.washington.edu/paper.pdf"
+    pdf: "https://arxiv.org/abs/2606.30560"
     code: "https://github.com/uw-syfi/TraceLab"
     website: "https://tracelab.cs.washington.edu/"
 

--- a/_posts/2026-06-25-tracelab.md
+++ b/_posts/2026-06-25-tracelab.md
@@ -93,11 +93,13 @@ This trace offers an early, concrete look at what real coding-agent traffic look
 TraceLab is open source. If you build on this work, please cite it:
 
 ```bibtex
-@misc{zhu2026tracelab,
-  title        = {TraceLab: Characterizing Coding Agent Workloads for LLM Serving},
-  author       = {Kan Zhu and Mathew Jacob and Chenxi Ma and Yi Pan and Stephanie Wang and Arvind Krishnamurthy and Baris Kasikci},
-  year         = {2026},
-  howpublished = {\url{https://tracelab.cs.washington.edu}},
-  note         = {SyFI Lab, University of Washington}
+@misc{zhu2026tracelabcharacterizingcodingagent,
+  title         = {TraceLab: Characterizing Coding Agent Workloads for LLM Serving},
+  author        = {Kan Zhu and Mathew Jacob and Chenxi Ma and Yi Pan and Stephanie Wang and Arvind Krishnamurthy and Baris Kasikci},
+  year          = {2026},
+  eprint        = {2606.30560},
+  archivePrefix = {arXiv},
+  primaryClass  = {cs.LG},
+  url           = {https://arxiv.org/abs/2606.30560}
 }
 ```


### PR DESCRIPTION
## What this changes

The TraceLab blog post and publication entry are already live (via #57). This is
a small follow-up that points the paper references at the now-public arXiv
preprint.

## Changes
- `_data/publications.yml`: TraceLab `pdf:` → `https://arxiv.org/abs/2606.30560`
- `_posts/2026-06-25-tracelab.md`: BibTeX → arXiv `@misc` entry (eprint `2606.30560`, `cs.LG`)

Net diff is these two files on top of `jekyll`; `jekyll` is an ancestor, so it merges cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)