### PR TITLE
Add unified tag system and filterable /research/ page

### DIFF
--- a/_data/publications.yml
+++ b/_data/publications.yml
@@ -3,7 +3,7 @@ index:
     title: "TraceLab: Characterizing Coding Agent Workloads for LLM Serving"
     authors: ["Kan Zhu", "Mathew Jacob", "Chenxi Ma", "Yi Pan", "Stephanie Wang", "Arvind Krishnamurthy", "Baris Kasikci"]
     year: 2026
-    topics: ["LLM Serving"]
+    tags: [inference, agents]
     link: "https://syfi.cs.washington.edu/blog/2026-06-25-tracelab/"
     pdf: "https://arxiv.org/abs/2606.30560"
     code: "https://github.com/uw-syfi/TraceLab"
@@ -13,7 +13,7 @@ index:
     title: "Piper: A Programmable Distributed Training System"
     authors: ["Megan Frisella", "Shubham Tiwari", "Andy Ruan", "Yi Pan", "Parker Gustafson", "Mat Jacob", "Gilbert Bernstein", "Stephanie Wang"]
     year: 2026
-    topics: ["Distributed Training"]
+    tags: [training, programmability]
     link: "https://syfi.cs.washington.edu/blog/2026-06-05-piper/"
     pdf: "https://arxiv.org/abs/2606.11169"
     code: "https://github.com/uw-syfi/piper"
@@ -22,7 +22,7 @@ index:
     title: "M*: A Modular, Extensible, Serving System for Multimodal Models"
     authors: ["Atindra Jha", "Naomi Sagan", "Keisuke Kamahori", "Irmak Sivgin", "Rohan Sanda", "Steven Gao", "Mark Horowitz", "Luke Zettlemoyer", "Olivia Hsu", "Jure Leskovec", "Baris Kasikci", "Stephanie Wang"]
     year: 2026
-    topics: ["LLM Serving"]
+    tags: [inference, multimodal, programmability]
     link: "https://m-star.org/"
     pdf: "https://arxiv.org/abs/2606.12688"
     code: "https://github.com/mstar-project/mstar"
@@ -31,7 +31,7 @@ index:
     title: "MURMUR: An Efficient Inference System for Long-Form ASR"
     authors: ["Wei-Tzu Lee", "Keisuke Kamahori", "Baris Kasikci"]
     year: 2026
-    topics: ["LLM Serving"]
+    tags: [inference, multimodal]
     pdf: "https://arxiv.org/abs/2606.01483"
     code: "https://github.com/uw-syfi/Murmur"
 
@@ -39,7 +39,7 @@ index:
     title: "VibeServe: Can AI Agents Build Bespoke LLM Serving Systems?"
     authors: ["Keisuke Kamahori", "Shihang Li", "Simon Peter", "Baris Kasikci"]
     year: 2026
-    topics: ["LLM Serving"]
+    tags: [inference, agents]
     link: "https://syfi.cs.washington.edu/blog/2026-05-12-introducing-vibeserve/"
     pdf: "https://arxiv.org/abs/2605.06068"
     code: "https://github.com/uw-syfi/vibe-serve"
@@ -48,7 +48,7 @@ index:
     title: "VoxServe: Streaming-Centric Serving System for Speech Language Models"
     authors: ["Keisuke Kamahori", "Wei-Tzu Lee", "Atindra Jha", "Rohan Kadekodi", "Stephanie Wang", "Arvind Krishnamurthy", "Baris Kasikci"]
     year: 2026
-    topics: ["LLM Serving"]
+    tags: [inference, multimodal]
     link: "https://syfi.cs.washington.edu/blog/2025-09-29-introducing-vox-serve/"
     pdf: "https://arxiv.org/abs/2602.00269"
     code: "https://github.com/vox-serve/vox-serve"
@@ -58,7 +58,7 @@ index:
     authors: ["Aditya K Kamath", "Arvind Krishnamurthy", "Marco Canini", "Simon Peter"]
     venue: "European Conference on Computer Systems (EuroSys)"
     year: 2026
-    topics: ["Efficient AI"]
+    tags: [training]
     pdf: "/assets/papers/ibp.pdf"
 
   - id: "flashinfer-bench"
@@ -66,7 +66,7 @@ index:
     authors: ["Shanli Xing", "Yiyan Zhai", "Alexander Jiang", "Yixin Dong", "Yong Wu", "Zihao Ye", "Charlie Ruan", "Yingyi Huang", "Yineng Zhang", "Liangsheng Yin", "Aksara Bayyapu", "Luis Ceze", "Tianqi Chen"]
     venue: "Annual Conference on Machine Learning and Systems (MLSys)"
     year: 2026
-    topics: ["LLM Serving"]
+    tags: [inference, agents]
     pdf: "https://arxiv.org/abs/2601.00227"
 
   - id: "sparsespec"
@@ -74,7 +74,7 @@ index:
     authors: ["Yilong Zhao", "Jiaming Tang", "Kan Zhu", "Zihao Ye", "Chi-Chih Chang", "Chaofan Lin", "Jongseok Park", "Guangxuan Xiao", "Mohamed S. Abdelfattah", "Mingyu Gao", "Baris Kasikci", "Song Han", "Ion Stoica"]
     venue: "Annual Conference on Machine Learning and Systems (MLSys)"
     year: 2026
-    topics: ["LLM Serving"]
+    tags: [inference]
     pdf: "https://arxiv.org/abs/2512.01278"
 
   - id: "dynaflow"
@@ -83,7 +83,7 @@ index:
     authors: ["Yi Pan", "Yile Gu", "Jinbin Luo", "Yibo Wu", "Ziren Wang", "Hongtao Zhang", "Ziyi Xu", "Shengkai Lin", "Baris Kasikci", "Stephanie Wang"]
     venue: "Annual Conference on Machine Learning and Systems (MLSys)"
     year: 2026
-    topics: ["Efficient AI"]
+    tags: [inference, programmability]
     areas: ["efficient_ai", "flexible_ai"]
     show_in_venn: true
 
@@ -92,7 +92,7 @@ index:
     authors: ["Yilong Zhao", "Xiaonan Nie", "Kan Zhu", "Shuang Ma", "Zhichao Lai", "Hongxiang Hao", "Yang Zhou", "Baris Kasikci", "Ion Stoica"]
     venue: "Annual Conference on Machine Learning and Systems (MLSys)"
     year: 2026
-    topics: ["Distributed Training"]
+    tags: [training]
 
   - id: "telerag"
     title: "TeleRAG: Efficient Retrieval-Augmented Generation Inference with Lookahead Retrieval"
@@ -100,7 +100,7 @@ index:
     authors: ["Chien-Yu Lin", "Keisuke Kamahori", "Yiyu Liu", "Xiaoxiang Shi", "Madhav Kashyap", "Yile Gu", "Rulin Shao", "Zihao Ye", "Kan Zhu", "Stephanie Wang", "Arvind Krishnamurthy", "Rohan Kadekodi", "Luis Ceze", "Baris Kasikci"]
     venue: "Annual Conference on Machine Learning and Systems (MLSys)"
     year: 2026
-    topics: ["LLM Serving"]
+    tags: [inference, data]
     areas: ["efficient_ai"]
     show_in_venn: true
     link: "https://syfi.cs.washington.edu/publications/telerag/"
@@ -112,14 +112,14 @@ index:
     authors: ["Kan Zhu", "Tian Tang", "Qinyu Xu", "Yile Gu", "Zhichen Zeng", "Rohan Kadekodi", "Liangyu Zhao", "Ang Li", "Arvind Krishnamurthy", "Baris Kasikci"]
     venue: "International Conference on Learning Representations (ICLR)"
     year: 2026
-    topics: ["LLM Serving"]
+    tags: [inference]
     pdf: "https://arxiv.org/pdf/2502.12216"
 
   - id: "raydata"
     title: "The Streaming Batch Model for Efficient and Fault-Tolerant Heterogeneous Execution"
     authors: ["Frank Sifei Luan", "Ron Yifeng Wang", "Yile Gu", "Ziming Mao", "Charlotte Lin", "Amog Kamsetty", "Hao Chen", "Cheng Su", "Balaji Veeramani", "Scott Lee", "SangBin Cho", "Clark Zinzow", "Eric Liang", "Ion Stoica", "Stephanie Wang"]
     year: 2025
-    topics: ["ML+Data", "Efficient AI", "Flexible AI"]
+    tags: [data, training]
     pdf: "https://arxiv.org/abs/2501.12407"
 
   - id: "distscheduling"
@@ -127,7 +127,7 @@ index:
     authors: ["Yuyao Wang", "Xiangfeng Zhu", "Ratul Mahajan", "Stephanie Wang"]
     venue: "Hot Topics in Networks (HotNets)"
     year: 2025
-    topics: ["Distributed Scheduling"]
+    tags: [programmability]
     pdf: "https://dl.acm.org/doi/10.1145/3772356.3772391"
 
   - id: "piper"
@@ -136,7 +136,7 @@ index:
     authors: ["Megan Frisella", "Arvin Oentoro", "Xiangyu Gao", "Gilbert Bernstein", "Stephanie Wang"]
     venue: "Practical Adoption Challenges of ML for Systems (PACMI)"
     year: 2025
-    topics: ["Distributed Training"]
+    tags: [training, programmability]
     areas: ["efficient_ai", "flexible_ai"]
     show_in_venn: true
     link: "https://syfi.cs.washington.edu/publications/piper/"
@@ -147,7 +147,7 @@ index:
     authors: ["Keisuke Kamahori", "Jungo Kasai", "Noriyuki Kojima", "Baris Kasikci"]
     venue: "Conference on Empirical Methods in Natural Language Processing (EMNLP)"
     year: 2025
-    topics: ["Efficient ML"]
+    tags: [inference, multimodal]
     link: "https://syfi.cs.washington.edu/publications/liteasr/"
     pdf: "https://arxiv.org/abs/2502.20583"
     code: "https://github.com/efeslab/LiteASR"
@@ -158,7 +158,7 @@ index:
     authors: ["Zihao Ye", "Lequn Chen", "Ruihang Lai", "Wuwei Lin", "Yineng Zhang", "Stephanie Wang", "Tianqi Chen", "Baris Kasikci", "Vinod Grover", "Arvind Krishnamurthy", "Luis Ceze"]
     venue: "Annual Conference on Machine Learning and Systems (MLSys)"
     year: 2025
-    topics: ["LLM Serving"]
+    tags: [inference]
     areas: ["efficient_ai", "flexible_ai"]
     show_in_venn: true
     pdf: "https://arxiv.org/abs/2501.01005"
@@ -171,7 +171,7 @@ index:
     authors: ["Yile Gu", "Hoang Doan Nguyen", "Demirhan Celik", "Sifat Hasan", "Yifan Xiong", "Jonathan Mace", "Yuting Jiang", "Yigong Hu", "Baris Kasikci", "Peng Cheng"]
     venue: "arXiv preprint (2025)"
     year: 2025
-    topics: ["Agents", "Cloud Reliability"]
+    tags: [agents, reliability]
     pdf: "https://arxiv.org/pdf/2501.14170"
 
   - id: "nanoflow"
@@ -180,7 +180,7 @@ index:
     authors: ["Kan Zhu", "Yufei Gao", "Yilong Zhao", "Liangyu Zhao", "Gefei Zuo", "Yile Gu", "Dedong Xie", "Tian Tang", "Qinyu Xu", "Zihao Ye", "Keisuke Kamahori", "Chien-Yu Lin", "Ziren Wang", "Stephanie Wang", "Arvind Krishnamurthy", "Baris Kasikci"]
     venue: "Symposium on Operating Systems Design and Implementation (OSDI)"
     year: 2025
-    topics: ["LLM Serving"]
+    tags: [inference]
     areas: ["efficient_ai", "flexible_ai"]
     show_in_venn: true
     pdf: "https://arxiv.org/abs/2408.12757v1"
@@ -193,7 +193,7 @@ index:
     authors: ["Yi Pan", "Wenbo Qian", "Dedong Xie", "Ruiyan Hu", "Yigong Hu", "Baris Kasikci"]
     venue: "arXiv preprint (2025)"
     year: 2025
-    topics: ["Energy Efficiency", "ML Systems"]
+    tags: [reliability]
     areas: ["efficient_ai", "resilient_ai"]
     show_in_venn: true
     link: "https://syfi.cs.washington.edu/publications/magneton/"
@@ -203,7 +203,7 @@ index:
     authors: ["Weixin Deng", "Andy Ruan", "Megan Frisella", "Kai-Hsun Chen", "SangBin Cho", "Jack Tigar Humphries", "Rui Qiao", "Stephanie Wang"]
     venue: "Hot Topics in Operating Systems (HotOS)"
     year: 2025
-    topics: ["Flexible AI", "Efficient AI"]
+    tags: [programmability]
     pdf: "https://dl.acm.org/doi/10.1145/3713082.3730392"
 
   - id: "fiddler"
@@ -212,7 +212,7 @@ index:
     authors: ["Keisuke Kamahori", "Tian Tang", "Yile Gu", "Kan Zhu", "Baris Kasikci"]
     venue: "International Conference on Learning Representations (ICLR)"
     year: 2025
-    topics: ["LLM Serving"]
+    tags: [inference]
     areas: ["efficient_ai"]
     show_in_venn: true
     pdf: "https://arxiv.org/pdf/2402.07033"
@@ -224,7 +224,7 @@ index:
     authors: ["Jeffrey Li", "Alex Fang", "Georgios Smyrnis", "Maor Ivgi", "Matt Jordan", "Samir Gadre", "Hritik Bansal", "Etash Guha", "Sedrick Keh", "Kushal Arora", "Saurabh Garg", "Rui Xin", "Niklas Muennighoff", "Reinhard Heckel", "Jean Mercat", "Mayee Chen", "Suchin Gururangan", "Mitchell Wortsman", "Alon Albalak", "Yonatan Bitton", "Marianna Nezhurina", "Amro Abbas", "Cheng-Yu Hsieh", "Dhruba Ghosh", "Josh Gardner", "Maciej Kilian", "Hanlin Zhang", "Rulin Shao", "Sarah Pratt", "Sunny Sanyal", "Gabriel Ilharco", "Giannis Daras", "Kalyani Marathe", "Aaron Gokaslan", "Jieyu Zhang", "Khyathi Chandu", "Thao Nguyen", "Igor Vasiljevic", "Sham Kakade", "Shuran Song", "Sujay Sanghavi", "Fartash Faghri", "Sewoong Oh", "Luke Zettlemoyer", "Kyle Lo", "Alaaeldin El-Nouby", "Hadi Pouransari", "Alexander Toshev", "Stephanie Wang", "Dirk Groeneveld", "Luca Soldaini", "Pang Wei Koh", "Jenia Jitsev", "Thomas Kollar", "Alexandros G Dimakis", "Yair Carmon", "Achal Dave", "Ludwig Schmidt", "Vaishaal Shankar"]
     venue: "Conference on Neural Information Processing Systems (NeurIPS)"
     year: 2024
-    topics: ["ML+Data"]
+    tags: [data]
     pdf: "https://proceedings.neurips.cc/paper_files/paper/2024/hash/19e4ea30dded58259665db375885e412-Abstract-Datasets_and_Benchmarks_Track.html"
 
   - id: "quest"
@@ -232,7 +232,7 @@ index:
     authors: ["Jiaming Tang", "Yilong Zhao", "Kan Zhu", "Guangxuan Xiao", "Baris Kasikci", "Song Han"]
     venue: "International Conference on Machine Learning (ICML)"
     year: 2024
-    topics: ["LLM Serving"]
+    tags: [inference]
     pdf: "https://arxiv.org/pdf/2406.10774"
     code: "https://github.com/mit-han-lab/Quest"
     link: "https://syfi.cs.washington.edu/publications/quest/"
@@ -243,7 +243,7 @@ index:
     authors: ["Yilong Zhao", "Chien-Yu Lin", "Kan Zhu", "Zihao Ye", "Lequn Chen", "Size Zheng", "Luis Ceze", "Arvind Krishnamurthy", "Tianqi Chen", "Baris Kasikci"]
     venue: "Annual Conference on Machine Learning and Systems (MLSys)"
     year: 2024
-    topics: ["LLM Serving"]
+    tags: [inference]
     areas: ["efficient_ai"]
     show_in_venn: true
     pdf: "https://arxiv.org/pdf/2310.19102"

--- a/_data/tags.yml
+++ b/_data/tags.yml
@@ -1,0 +1,30 @@
+# Canonical tag vocabulary shared by papers and blog posts.
+#
+# - Blog posts (_posts/*.md) declare `tags: [<slugs>]` in their front matter,
+#   typically starting with the post kind (research / lab-update).
+# - Publications (_data/publications.yml and publications/*.md) declare
+#   `tags: [<slugs>]`.
+#
+# The /research/ page filters both kinds of content by these slugs.
+
+tags:
+  # Blog post kinds
+  - slug: research
+    label: "New Research"
+  - slug: lab-update
+    label: "Lab Update"
+  # Research areas
+  - slug: inference
+    label: "Inference & Serving"
+  - slug: training
+    label: "Training"
+  - slug: agents
+    label: "Agents"
+  - slug: multimodal
+    label: "Multimodal"
+  - slug: data
+    label: "ML + Data"
+  - slug: reliability
+    label: "Reliability & Energy"
+  - slug: programmability
+    label: "Programmable Systems"

--- a/_includes/tag_badges.html
+++ b/_includes/tag_badges.html
@@ -1,0 +1,5 @@
+{% comment %}
+Clickable tag badges that deep-link into the filterable /research/ page.
+Usage: {% include tag_badges.html tags=page.tags %}
+  - tags: array of tag slugs (see _data/tags.yml)
+{% endcomment %}{% for _slug in include.tags %}{% assign _tag = site.data.tags.tags | where: "slug", _slug | first %}{% if _tag %}<a href="{{ site.github.url }}/research/?tag={{ _tag.slug }}" class="badge rounded-pill bg-light text-dark border text-decoration-none me-1">{{ _tag.label }}</a>{% endif %}{% endfor %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -6,6 +6,7 @@ layout: default
   <div class="col-md-12 post-content">
     <h1 class="fw-bold mb-2">{{ page.title }}</h1>
     {% if page.author %}<p class="text-muted mb-1">{{ page.author }}</p>{% endif %}
+    {% if page.tags %}<p class="mb-2">{% include tag_badges.html tags=page.tags %}</p>{% endif %}
     <p class="text-muted border-bottom pb-3 mb-5">{{ page.date | date: "%B %-d, %Y" }}</p>
     {{ content }}
   </div>

--- a/_layouts/publication.html
+++ b/_layouts/publication.html
@@ -19,7 +19,9 @@ layout: default
     </p>
     {% endif %}
 
-    {% if page.topics %}
+    {% if page.tags %}
+    <p class="mb-2">{% include tag_badges.html tags=page.tags %}</p>
+    {% elsif page.topics %}
     <p class="mb-2">
       {% for topic in page.topics %}
         <span class="badge bg-secondary me-1">{{ topic }}</span>

--- a/_posts/2025-09-29-introducing-vox-serve.md
+++ b/_posts/2025-09-29-introducing-vox-serve.md
@@ -4,6 +4,7 @@ title: "Efficient Serving of SpeechLMs with VoxServe"
 date: 2025-09-29
 author: "Keisuke Kamahori, Baris Kasikci"
 excerpt: "We present VoxServe, a high-throughput, low-latency serving system designed specifically for Speech Language Models."
+tags: [research, inference, multimodal]
 ---
 
 *This article is cross-posted from [https://vox-serve.github.io/2025/09/29/introducing-vox-serve.html](https://vox-serve.github.io/2025/09/29/introducing-vox-serve.html).*

--- a/_posts/2025-10-03-llmc-compression.md
+++ b/_posts/2025-10-03-llmc-compression.md
@@ -4,6 +4,7 @@ title: "Meet LLMc: Beating All Compression with LLMs"
 date: 2025-10-03
 author: "UW SyFI Lab"
 excerpt: "We present LLMc, an open-source tool to compress natural language using LLMs as the world's most reference-packed dictionary."
+tags: [research, inference]
 ---
 
 <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>

--- a/_posts/2026-01-31-syfi-january-2026.md
+++ b/_posts/2026-01-31-syfi-january-2026.md
@@ -4,6 +4,7 @@ title: "SyFI in January 2026: A Big Month for Systems-Driven AI Research"
 date: 2026-01-31
 author: "UW SyFI Lab"
 excerpt: "January 2026 was a milestone month for the SyFI Lab, with six papers published across MLSys and ICLR—spanning inference, training, scheduling, retrieval, and model architecture."
+tags: [lab-update, inference, training, data]
 ---
 
 January 2026 was a milestone month for the SyFI Lab. Our group published **six papers across MLSys and ICLR together with our collaborators**—five at *MLSys 2026* and one at *ICLR 2026*—spanning inference, training, scheduling, retrieval, and model architecture. While each paper tackles a specific systems challenge, together they reflect a shared goal: **making large-scale AI systems faster, more flexible, and more practical in the real world**.

--- a/_posts/2026-05-12-introducing-vibeserve.md
+++ b/_posts/2026-05-12-introducing-vibeserve.md
@@ -4,6 +4,7 @@ title: "Let AI Agents Write Your Serving Stack with VibeServe"
 date: 2026-05-12
 author: "Keisuke Kamahori, Shihang Vic Li, Simon Peter, Baris Kasikci"
 excerpt: "We present VibeServe, a multi-agent system that synthesizes a complete LLM serving runtime end-to-end, specialized to a user-specified model, hardware, and workload."
+tags: [research, inference, agents]
 ---
 
 **TL;DR:** Generic LLM serving stacks cover the mainstream use cases well, but struggle on the long tail of new models, accelerators, and workloads. **VibeServe** is a multi-agent system that synthesizes a complete serving runtime end-to-end, specialized to a user-specified model, hardware, and workload. Across six case studies, it matches vLLM and SGLang on a heavily optimized mainstream setup (Llama-3.1-8B on H100) and delivers **1.69×–6.27×** speedups on non-standard ones. This is early evidence that **AI agents can build an entire system end-to-end** and **beat human-engineered baselines on long-horizon performance work**.

--- a/_posts/2026-05-28-mlsys-kernel-contest.md
+++ b/_posts/2026-05-28-mlsys-kernel-contest.md
@@ -4,6 +4,7 @@ title: "SyFI Team Wins CUDA Kernel Agent Contest at MLSys 2026"
 date: 2026-05-28
 author: "Keisuke Kamahori, Steven Gao, Vic Shihang Li, Wei Shen, Yile Gu"
 excerpt: "Team UW SyFI won three awards across two tracks at the FlashInfer AI Kernel Generation Contest at MLSys 2026 — every line of kernel code written by coding agents, not humans."
+tags: [lab-update, agents]
 ---
 
 At the [**FlashInfer AI Kernel Generation Contest**](https://mlsys26.flashinfer.ai/) at MLSys 2026, Team UW SyFI received awards in three categories out of 245 submissions:

--- a/_posts/2026-06-05-piper.md
+++ b/_posts/2026-06-05-piper.md
@@ -4,6 +4,7 @@ title: "Introducing Piper: A Programmable Distributed Training System"
 date: 2026-06-05
 author: "Megan Frisella, Shubham Tiwari, Andy Ruan, Yi Pan, Parker Gustafson, Mat Jacob, Gilbert Bernstein, Stephanie Wang"
 excerpt: "We present Piper, a programmable distributed training system that uses model annotations and scheduling directives to express model placement, pipeline scheduling, and GPU stream scheduling."
+tags: [research, training, programmability]
 ---
 
 **TL;DR:** New distributed training strategies and optimizations should not require new distributed runtimes.

--- a/_posts/2026-06-19-mstar.md
+++ b/_posts/2026-06-19-mstar.md
@@ -4,6 +4,7 @@ title: "M*: A Modular, Extensible, Serving System for Multimodal Models"
 date: 2026-06-19
 author: "Atindra Jha, Naomi Sagan, Keisuke Kamahori, Xikai (Noah) Meng, Rohan Sanda, Luke Zettlemoyer, Olivia Hsu, Jure Leskovec, Baris Kasikci, Stephanie Wang"
 excerpt: "Today's models no longer fit the mold of autoregressive token generation. M* treats composite multimodal models as dataflow graphs and requests as Walks on those graphs, serving image, audio, video, and robot-action models at or above the performance of specialized engines."
+tags: [research, inference, multimodal, programmability]
 ---
 
 *This article is cross-posted from [https://m-star.org/](https://m-star.org/).*

--- a/_posts/2026-06-25-tracelab.md
+++ b/_posts/2026-06-25-tracelab.md
@@ -4,6 +4,7 @@ title: "TraceLab: Characterizing Coding Agent Workloads for LLM Serving"
 date: 2026-06-25
 author: "Kan Zhu, Mathew Jacob, Chenxi Ma, Yi Pan, Stephanie Wang, Arvind Krishnamurthy, Baris Kasikci"
 excerpt: "As coding agents become a major LLM application, serving them efficiently is an open systems problem. We release the SyFI coding trace — ~4,300 real sessions and 55B tokens for performance modeling from our daily Claude Code and Codex use — and TraceLab, an open pipeline to collect, sanitize, analyze, and replay your own coding agent traces."
+tags: [research, inference, agents]
 ---
 
 ## Overview

--- a/blog.md
+++ b/blog.md
@@ -7,6 +7,7 @@ title: "Blog"
 <div class="row g-5 mb-5">
   <div class="col-md-12">
     <h5><a href="{{ site.github.url }}{{ post.url }}">{{ post.title }}</a></h5>
+    <p class="mb-1">{% include tag_badges.html tags=post.tags %}</p>
     <p class="text-muted">{{ post.date | date: "%B %d, %Y" }}</p>
     {{ post.excerpt }}
   </div>

--- a/publications.md
+++ b/publications.md
@@ -13,6 +13,7 @@ title: "Publications"
       <h5><a href="{{ pub.pdf }}">{{ pub.title }}</a></h5>
     {% endif %}
     {% if pub.award %}<span class="badge bg-warning text-dark">{{ pub.award }}</span>{% endif %}
+    {% if pub.tags %}<p class="mb-1">{% include tag_badges.html tags=pub.tags %}</p>{% endif %}
     <p class="text-muted">{{ pub.authors | join: ", " }} &mdash; {{ pub.venue }} ({{ pub.year }})</p>
     <div class="d-flex gap-2">
       {% if pub.pdf %}

--- a/publications/argos.md
+++ b/publications/argos.md
@@ -1,10 +1,11 @@
 ---
 layout: publication
-title: "Argos: Detecting Dynamic Anomalies in the Cloud with Rule Generation
+title: "Argos: Detecting Dynamic Anomalies in the Cloud with Rule Generation"
 authors: ["Yile Gu", "Hoang Doan Nguyen", "Demirhan Celik", "Sifat Hasan", "Yifan Xiong", "Jonathan Mace", "Yuting Jiang", "Yigong Hu", "Baris Kasikci", "Peng Cheng"]
 venue: "arXiv preprint (2025)"
 year: 2025
 topics: ["Agents", "Cloud Reliability"]
+tags: [agents, reliability]
 pdf: "https://arxiv.org/pdf/2501.14170"
 tldr: "Argos is an agentic system that leverages Large Language Models (LLMs) to automatically generate and refine explainable, reproducible Python rules for detecting dynamic cloud anomalies."
 keywords:

--- a/publications/atom.md
+++ b/publications/atom.md
@@ -5,6 +5,7 @@ authors: ["Yilong Zhao", "Chien-Yu Lin", "Kan Zhu", "Zihao Ye", "Lequn Chen", "S
 venue: "Annual Conference on Machine Learning and Systems (MLSys)"
 year: 2024
 topics: ["LLM Serving"]
+tags: [inference]
 pdf: "https://arxiv.org/pdf/2310.19102"
 code: "https://github.com/efeslab/Atom"
 tldr: "Atom is a low-bit quantization method for LLM serving that achieves up to 7.73x throughput improvement over FP16 and 2.53x over INT8, with negligible accuracy loss, by leveraging 4-bit integer operators and mixed-precision quantization."

--- a/publications/dynaflow.md
+++ b/publications/dynaflow.md
@@ -5,6 +5,7 @@ authors: ["Yi Pan", "Yile Gu", "Jinbin Luo", "Yibo Wu", "Ziren Wang", "Hongtao Z
 venue: "arXiv preprint (2025)"
 year: 2025
 topics: ["ML Systems"]
+tags: [inference, programmability]
 pdf: "https://syfi.cs.washington.edu/publications/dynaflow"
 tldr: "DynaFlow is a programmable intra-device parallelism framework for ML systems that achieves high performance and low effort."
 keywords:

--- a/publications/fiddler.md
+++ b/publications/fiddler.md
@@ -5,6 +5,7 @@ authors: ["Keisuke Kamahori", "Tian Tang", "Yile Gu", "Kan Zhu", "Baris Kasikci"
 venue: "International Conference on Learning Representations (ICLR)"
 year: 2025
 topics: ["LLM Serving"]
+tags: [inference]
 pdf: "https://arxiv.org/pdf/2402.07033"
 code: "https://github.com/efeslab/fiddler"
 tldr: "Fiddler is a resource-efficient inference system for Mixture-of-Experts (MoE) models that achieves lower latency than existing offloading methods by orchestrating CPU and GPU resources to minimize data movement."

--- a/publications/liteasr.md
+++ b/publications/liteasr.md
@@ -5,6 +5,7 @@ authors: ["Keisuke Kamahori", "Jungo Kasai", "Noriyuki Kojima", "Baris Kasikci"]
 venue: "Conference on Empirical Methods in Natural Language Processing (EMNLP)"
 year: 2025
 topics: ["Efficient ML", "Speech"]
+tags: [inference, multimodal]
 pdf: "https://arxiv.org/abs/2502.20583"
 code: "https://github.com/efeslab/LiteASR"
 tldr: "LiteASR is a low-rank compression scheme for ASR encoders that reduces Whisper Large-v3's encoder size by over 40% and improves inference speed by ~1.4x while maintaining transcription accuracy."

--- a/publications/magneton.md
+++ b/publications/magneton.md
@@ -5,6 +5,7 @@ authors: ["Yi Pan", "Wenbo Qian", "Dedong Xie", "Ruiyan Hu", "Yigong Hu", "Baris
 venue: "arXiv preprint (2025)"
 year: 2025
 topics: ["Energy Efficiency", "ML Systems"]
+tags: [reliability]
 pdf: "https://syfi.cs.washington.edu/publications/magneton"
 tldr: "Magneton is a differential energy profiler designed to detect and diagnose invisible inefficiencies in ML systems."
 keywords:

--- a/publications/nanoflow.md
+++ b/publications/nanoflow.md
@@ -5,6 +5,7 @@ authors: ["Kan Zhu", "Yufei Gao", "Yilong Zhao", "Liangyu Zhao", "Gefei Zuo", "Y
 venue: "Symposium on Operating Systems Design and Implementation (OSDI)"
 year: 2025
 topics: ["LLM Serving"]
+tags: [inference]
 pdf: "https://arxiv.org/abs/2408.12757v1"
 code: "https://github.com/efeslab/Nanoflow"
 tldr: "NanoFlow is a throughput-oriented high-performance serving framework for LLMs that achieves up to 1.91x throughput boost compared to TensorRT-LLM by exploiting intra-device parallelism and asynchronous CPU scheduling."

--- a/publications/piper.md
+++ b/publications/piper.md
@@ -5,6 +5,7 @@ authors: ["Megan Frisella", "Arvin Oentoro", "Xiangyu Gao", "Gilbert Bernstein",
 venue: "Practical Adoption Challenges of ML for Systems (PACMI)"
 year: 2025
 topics: ["Distributed Training"]
+tags: [training, programmability]
 pdf: "https://dl.acm.org/doi/10.1145/3766882.3767187"
 tldr: "Piper is a PyTorch library for training large models with flexible pipeline parallel schedules."
 keywords:

--- a/publications/quest.md
+++ b/publications/quest.md
@@ -5,6 +5,7 @@ authors: ["Jiaming Tang", "Yilong Zhao", "Kan Zhu", "Guangxuan Xiao", "Baris Kas
 venue: "International Conference on Machine Learning (ICML)"
 year: 2024
 topics: ["LLM Serving"]
+tags: [inference]
 pdf: "https://arxiv.org/pdf/2406.10774"
 code: "https://github.com/mit-han-lab/Quest"
 tldr: "Quest is a query-aware sparsity technique for long-context LLM inference that achieves up to 7.03x self-attention speedup and 2.23x latency reduction by selectively loading only the most critical KV cache pages based on dynamic query-driven criticality estimation."

--- a/publications/telerag.md
+++ b/publications/telerag.md
@@ -5,6 +5,7 @@ authors: ["Chien-Yu Lin", "Keisuke Kamahori", "Yiyu Liu", "Xiaoxiang Shi", "Madh
 venue: "arXiv preprint"
 year: 2025
 topics: ["LLM Serving", "RAG"]
+tags: [inference, data]
 pdf: "https://arxiv.org/pdf/2502.20969"
 code: "https://github.com/efeslab/TeleRAG"
 tldr: "TeleRAG is an efficient RAG inference system that reduces latency and improves throughput using lookahead retrieval to prefetch data from CPU to GPU in parallel with LLM generation."

--- a/research.md
+++ b/research.md
@@ -1,0 +1,137 @@
+---
+layout: page
+title: "Research"
+permalink: /research/
+---
+
+<p class="text-muted">Browse our papers and blog posts together. Filter by type and research area, or search by title, author, and venue.</p>
+
+<div class="mb-4">
+  <input type="search" id="research-search" class="form-control mb-3" placeholder="Search by title, author, venue…" aria-label="Search papers and blog posts">
+  <div class="d-flex flex-wrap gap-2 mb-2" id="kind-filters" role="group" aria-label="Filter by content type">
+    <button type="button" class="btn btn-sm btn-outline-dark" data-filter="all">All</button>
+    <button type="button" class="btn btn-sm btn-outline-dark" data-filter="paper">Papers</button>
+    <button type="button" class="btn btn-sm btn-outline-dark" data-filter="post">Blog posts</button>
+  </div>
+  <div class="d-flex flex-wrap gap-2" id="tag-filters" role="group" aria-label="Filter by tag">
+    <button type="button" class="btn btn-sm btn-outline-secondary" data-tag="">All tags</button>
+    {% for t in site.data.tags.tags %}
+    <button type="button" class="btn btn-sm btn-outline-secondary" data-tag="{{ t.slug }}">{{ t.label }}</button>
+    {% endfor %}
+  </div>
+</div>
+
+<p id="no-results" class="text-muted d-none">No papers or blog posts match the current filters.</p>
+
+{% assign years = "" | split: "" %}
+{% for pub in site.data.publications.index %}{% assign years = years | push: pub.year %}{% endfor %}
+{% for post in site.posts %}{% assign post_year = post.date | date: "%Y" | plus: 0 %}{% assign years = years | push: post_year %}{% endfor %}
+{% assign years = years | uniq | sort | reverse %}
+
+{% for year in years %}
+<section class="research-year-group">
+  <h4 class="border-bottom pb-2 mb-4">{{ year }}</h4>
+  {% for post in site.posts %}
+    {% assign post_year = post.date | date: "%Y" | plus: 0 %}
+    {% if post_year == year %}
+  <div class="research-item mb-4" data-kind="post" data-tags="{{ post.tags | join: ' ' }}" data-search="{{ post.title | append: ' ' | append: post.author | downcase | escape }}">
+    <h5 class="mb-1"><a href="{{ site.github.url }}{{ post.url }}">{{ post.title }}</a></h5>
+    <p class="mb-1">
+      <a href="{{ site.github.url }}/research/?type=post" class="badge rounded-pill bg-dark text-decoration-none me-1">Blog</a>
+      {%- include tag_badges.html tags=post.tags -%}
+    </p>
+    <p class="text-muted small mb-0">Blog post &mdash; {{ post.date | date: "%B %-d, %Y" }}{% if post.author %} &mdash; {{ post.author }}{% endif %}</p>
+  </div>
+    {% endif %}
+  {% endfor %}
+  {% for pub in site.data.publications.index %}
+    {% if pub.year == year %}
+    {% assign pub_authors = pub.authors | join: ", " %}
+  <div class="research-item mb-4" data-kind="paper" data-tags="{{ pub.tags | join: ' ' }}" data-search="{{ pub.title | append: ' ' | append: pub_authors | append: ' ' | append: pub.venue | downcase | escape }}">
+    <h5 class="mb-1">
+      {% if pub.link %}<a href="{{ pub.link }}">{{ pub.title }}</a>{% elsif pub.pdf %}<a href="{{ pub.pdf }}">{{ pub.title }}</a>{% else %}{{ pub.title }}{% endif %}
+    </h5>
+    <p class="mb-1">
+      <a href="{{ site.github.url }}/research/?type=paper" class="badge rounded-pill bg-dark text-decoration-none me-1">Paper</a>
+      {%- include tag_badges.html tags=pub.tags -%}
+      {% if pub.award %}<span class="badge bg-warning text-dark">{{ pub.award }}</span>{% endif %}
+    </p>
+    <p class="text-muted small mb-1">{{ pub_authors }}{% if pub.venue %} &mdash; {{ pub.venue }}{% endif %} ({{ pub.year }})</p>
+    <p class="small mb-0">
+      {% if pub.pdf %}<a href="{{ pub.pdf }}" class="me-2">PDF</a>{% endif %}
+      {% if pub.code %}<a href="{{ pub.code }}" class="me-2">Code</a>{% endif %}
+      {% if pub.website %}<a href="{{ pub.website }}">Website</a>{% endif %}
+    </p>
+  </div>
+    {% endif %}
+  {% endfor %}
+</section>
+{% endfor %}
+
+<script>
+(function () {
+  var items = Array.prototype.slice.call(document.querySelectorAll('.research-item'));
+  var groups = Array.prototype.slice.call(document.querySelectorAll('.research-year-group'));
+  var kindBtns = Array.prototype.slice.call(document.querySelectorAll('#kind-filters button'));
+  var tagBtns = Array.prototype.slice.call(document.querySelectorAll('#tag-filters button'));
+  var searchBox = document.getElementById('research-search');
+  var noResults = document.getElementById('no-results');
+
+  var kind = 'all';
+  var tag = '';
+  var query = '';
+
+  function apply() {
+    var terms = query.toLowerCase().split(/\s+/).filter(Boolean);
+    var visible = 0;
+    items.forEach(function (el) {
+      var okKind = kind === 'all' || el.dataset.kind === kind;
+      var okTag = !tag || el.dataset.tags.split(' ').indexOf(tag) !== -1;
+      var okQuery = terms.every(function (t) { return el.dataset.search.indexOf(t) !== -1; });
+      var show = okKind && okTag && okQuery;
+      el.classList.toggle('d-none', !show);
+      if (show) visible++;
+    });
+    groups.forEach(function (g) {
+      var any = Array.prototype.some.call(g.querySelectorAll('.research-item'), function (el) {
+        return !el.classList.contains('d-none');
+      });
+      g.classList.toggle('d-none', !any);
+    });
+    noResults.classList.toggle('d-none', visible > 0);
+    kindBtns.forEach(function (b) { b.classList.toggle('active', b.dataset.filter === kind); });
+    tagBtns.forEach(function (b) { b.classList.toggle('active', b.dataset.tag === tag); });
+
+    var params = new URLSearchParams();
+    if (kind !== 'all') params.set('type', kind);
+    if (tag) params.set('tag', tag);
+    if (query) params.set('q', query);
+    var qs = params.toString();
+    history.replaceState(null, '', qs ? '?' + qs : location.pathname);
+  }
+
+  kindBtns.forEach(function (b) {
+    b.addEventListener('click', function () {
+      kind = (kind === b.dataset.filter) ? 'all' : b.dataset.filter;
+      apply();
+    });
+  });
+  tagBtns.forEach(function (b) {
+    b.addEventListener('click', function () {
+      tag = (tag === b.dataset.tag) ? '' : b.dataset.tag;
+      apply();
+    });
+  });
+  searchBox.addEventListener('input', function () {
+    query = searchBox.value;
+    apply();
+  });
+
+  var params = new URLSearchParams(location.search);
+  kind = params.get('type') || 'all';
+  tag = params.get('tag') || '';
+  query = params.get('q') || '';
+  if (query) searchBox.value = query;
+  apply();
+})();
+</script>


### PR DESCRIPTION
## Summary

- Adds a canonical tag vocabulary (`_data/tags.yml`) shared by papers and blog posts: post kinds (**New Research**, **Lab Update**) plus research areas (**Inference & Serving**, **Training**, **Agents**, **Multimodal**, **ML + Data**, **Reliability & Energy**, **Programmable Systems**).
- Tags every publication (`_data/publications.yml` and `publications/*.md`) and every blog post through a single `tags:` front-matter field — no separate type field.
- New **/research/** page that lists papers and blog posts together, grouped by year, with client-side filtering by kind (Papers / Blog posts) and tag, plus live text search over titles, authors, and venues. Filter state syncs to the URL (e.g. `/research/?tag=agents&type=post`) so filtered views are shareable. Vanilla JS only, GitHub Pages compatible.
- Clickable tag badges on the blog list, publications list, and post/publication detail pages (via a shared `_includes/tag_badges.html`) deep-link into the pre-filtered /research/ page. The page is intentionally not in the nav.
- Cleanup: removes the unused `topics:` field from `_data/publications.yml`, and fixes an unterminated title quote in `publications/argos.md` that was silently breaking that page's build.

Tag assignments per paper/post are my best judgment — worth a skim.

## Test plan

- `bundle exec jekyll build` passes with no errors
- Verified filter logic against the generated HTML for every kind/tag combination (item counts check out: 26 papers + 8 posts)
- Manually checked /research/, /blog/, /publications/, and detail pages locally

cc @vic-lsh

🤖 Generated with [Claude Code](https://claude.com/claude-code)